### PR TITLE
Update `curv-kzen` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,7 @@ crate-type = ["lib"]
 [dependencies]
 rayon = "1.1"
 serde = { version = "1.0", features = ["derive"] }
-
-[dependencies.curv]
-git = "https://github.com/KZen-networks/curv"
-tag = "v0.2.3"
+curv-kzen = "0.9.0"
 
 [dev-dependencies]
 bencher = "0.1"

--- a/src/dl_solvers.rs
+++ b/src/dl_solvers.rs
@@ -1,4 +1,6 @@
 use curv::arithmetic::traits::Modulo;
+use curv::arithmetic::One;
+use curv::arithmetic::Zero;
 use curv::BigInt;
 
 // see https://en.wikipedia.org/wiki/Pollard%27s_rho_algorithm_for_logarithms#:~:text=Pollard's%20rho%20algorithm%20for%20logarithms%20is%20an%20algorithm%20introduced%20by,solve%20the%20integer%20factorization%20problem.&text=of%20the%20equation-,.,using%20the%20Extended%20Euclidean%20algorithm
@@ -64,7 +66,10 @@ impl<'a> SimplePollard<'a> {
         }
         let nom = BigInt::mod_sub(&a, &big_a, &self.big_p);
         let denom = BigInt::mod_sub(&big_b, &b, &self.big_p);
-        let res = BigInt::modulus(&(BigInt::mod_inv(&denom, &self.big_p) * &nom), &self.big_p);
+        let res = BigInt::modulus(
+            &(BigInt::mod_inv(&denom, &self.big_p).unwrap() * &nom),
+            &self.big_p,
+        );
         Ok(res)
     }
 }
@@ -89,7 +94,7 @@ mod tests {
         assert_eq!(res.clone().unwrap(), BigInt::from(10));
         assert_eq!(
             simple_pollard.beta,
-            &BigInt::powm(&simple_pollard.alpha, &res.unwrap(), &simple_pollard.big_p)
+            &BigInt::mod_pow(&simple_pollard.alpha, &res.unwrap(), &simple_pollard.big_p)
         );
     }
 

--- a/src/elgamal.rs
+++ b/src/elgamal.rs
@@ -12,6 +12,9 @@ use crate::rfc7919_groups::{SupportedGroups, SRG};
 
 use curv::arithmetic::traits::Modulo;
 use curv::arithmetic::traits::Samplable;
+use curv::arithmetic::Converter;
+use curv::arithmetic::One;
+use curv::arithmetic::Zero;
 use curv::BigInt;
 
 impl ElGamalPP {
@@ -125,7 +128,7 @@ impl ElGamal {
         }
         let c1_x = BigInt::mod_pow(&c.c1, &sk.x, &sk.pp.p);
         let c1_x_inv = BigInt::mod_inv(&c1_x, &sk.pp.p);
-        Ok(BigInt::mod_mul(&c.c2, &c1_x_inv, &sk.pp.p))
+        Ok(BigInt::mod_mul(&c.c2, &c1_x_inv.unwrap(), &sk.pp.p))
     }
 
     //Enc(m1) mul Enc(m2) = Enc(m1m2)
@@ -206,7 +209,7 @@ impl ExponentElGamal {
         }
         let c1_x = BigInt::mod_pow(&c.c1, &sk.x, &sk.pp.p);
         let c1_x_inv = BigInt::mod_inv(&c1_x, &sk.pp.p);
-        Ok(BigInt::mod_mul(&c.c2, &c1_x_inv, &sk.pp.p))
+        Ok(BigInt::mod_mul(&c.c2, &c1_x_inv.unwrap(), &sk.pp.p))
     }
 
     //returns m

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod elgamal;
 pub mod prime;
 pub mod rfc7919_groups;
 
-pub use curv::arithmetic::big_gmp::BigInt;
+pub use curv::arithmetic::BigInt;
 
 pub struct ElGamal;
 pub struct ExponentElGamal;

--- a/src/prime.rs
+++ b/src/prime.rs
@@ -1,6 +1,9 @@
 use curv::arithmetic::traits::Modulo;
-use curv::arithmetic::traits::NumberTests;
 use curv::arithmetic::traits::Samplable;
+use curv::arithmetic::BitManipulation;
+use curv::arithmetic::Integer;
+use curv::arithmetic::One;
+use curv::arithmetic::Zero;
 use curv::BigInt;
 
 // Runs the following three tests on a given `candidate` to determine


### PR DESCRIPTION
Tests were failing with the following error:

```
error: failed to select a version for the requirement `zeroize = "^0.10"`
candidate versions found which didn't match: 1.4.3, 1.4.2, 1.4.1, ...
location searched: crates.io index
required by package `curv v0.2.3 (https://github.com/KZen-networks/curv?tag=v0.2.3#d6c575b5)`
    ... which is depended on by `elgamal v0.0.2 (/home/arturo/GitHub/rust-elgamal)`
```
This was solved by updating the `curv` dependency to its latest version ([`0.0.9`](https://docs.rs/curv-kzen/0.9.0/curv/)).

This change broke some lines that were updated. Specifically, some structs were explicitly brought into scope, and, most notably, the `BigInt::mod_inv` function now returns an `Option`, so `.unwrap()` was added to pass the tests. This last change could perhaps be handled in a better way though.